### PR TITLE
20210824 zrq updates

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#
+
+# -----------------------------------------------------
+# Check our secret function works.
+#[user@desktop]
+
+    secret frog
+
+# -----------------------------------------------------
+# Build our containers.
+#[user@desktop]
+
+    buildtag=$(date '+%Y.%m.%d')
+    buildtime=$(date '+%Y-%m-%dT%H:%M:%S')
+
+    source "${HOME}/atolmis.env"
+    pushd "${ATOLMIS_CODE:?}"
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/fedora:latest \
+            --tag atolmis/fedora:${buildtag:?} \
+            docker/fedora
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openssh-client:latest \
+            --tag atolmis/openssh-client:${buildtag:?} \
+            docker/openssh-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/kubernetes-client:latest \
+            --tag atolmis/kubernetes-client:${buildtag:?} \
+            docker/kubernetes-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openstack-client:latest \
+            --tag atolmis/openstack-client:${buildtag:?} \
+            docker/openstack-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/ansible-client:latest \
+            --tag atolmis/ansible-client:${buildtag:?} \
+            docker/ansible-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/terraform-client:latest \
+            --tag atolmis/terraform-client:${buildtag:?} \
+            docker/terraform-client
+
+    popd
+
+# -----------------------------------------------------
+# Login to the Docker registry.
+#[user@desktop]
+
+    podman login \
+        --username $(secret docker.io.user) \
+        --password $(secret docker.io.pass) \
+        registry-1.docker.io
+
+    #
+    # New behaviour - podman needs the registry name here.
+    #
+
+# -----------------------------------------------------
+# Push our images to Docker hub.
+#[user@desktop]
+
+    podman push "atolmis/fedora:${buildtag:?}"
+    podman push "atolmis/fedora:latest"
+
+    podman push "atolmis/openssh-client:${buildtag:?}"
+    podman push "atolmis/openssh-client:latest"
+
+    podman push "atolmis/kubernetes-client:${buildtag:?}"
+    podman push "atolmis/kubernetes-client:latest"
+
+    podman push "atolmis/openstack-client:${buildtag:?}"
+    podman push "atolmis/openstack-client:latest"
+
+    podman push "atolmis/ansible-client:${buildtag:?}"
+    podman push "atolmis/ansible-client:latest"
+
+    podman push "atolmis/terraform-client:${buildtag:?}"
+    podman push "atolmis/terraform-client:latest"
+
+

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,11 +19,6 @@
 #   </meta:licence>
 # </meta:header>
 #
-#zrq-notes-time
-#zrq-notes-indent
-#zrq-notes-crypto
-#zrq-notes-ansible
-#zrq-notes-osformat
 #
 
 # -----------------------------------------------------

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -27,12 +27,6 @@
 #
 
 # -----------------------------------------------------
-# Check our secret function works.
-#[user@desktop]
-
-    secret frog
-
-# -----------------------------------------------------
 # Build our containers.
 #[user@desktop]
 
@@ -85,40 +79,5 @@
             docker/terraform-client
 
     popd
-
-# -----------------------------------------------------
-# Login to the Docker registry.
-#[user@desktop]
-
-    podman login \
-        --username $(secret docker.io.user) \
-        --password $(secret docker.io.pass) \
-        registry-1.docker.io
-
-    #
-    # New behaviour - podman needs the registry name here.
-    #
-
-# -----------------------------------------------------
-# Push our images to Docker hub.
-#[user@desktop]
-
-    podman push "atolmis/fedora:${buildtag:?}"
-    podman push "atolmis/fedora:latest"
-
-    podman push "atolmis/openssh-client:${buildtag:?}"
-    podman push "atolmis/openssh-client:latest"
-
-    podman push "atolmis/kubernetes-client:${buildtag:?}"
-    podman push "atolmis/kubernetes-client:latest"
-
-    podman push "atolmis/openstack-client:${buildtag:?}"
-    podman push "atolmis/openstack-client:latest"
-
-    podman push "atolmis/ansible-client:${buildtag:?}"
-    podman push "atolmis/ansible-client:latest"
-
-    podman push "atolmis/terraform-client:${buildtag:?}"
-    podman push "atolmis/terraform-client:latest"
 
 

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -19,11 +19,6 @@
 #   </meta:licence>
 # </meta:header>
 #
-#zrq-notes-time
-#zrq-notes-indent
-#zrq-notes-crypto
-#zrq-notes-ansible
-#zrq-notes-osformat
 #
 
 # -----------------------------------------------------

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#
+
+# -----------------------------------------------------
+# Dele all our containers.
+#[user@desktop]
+
+    podman rm -f $(podman ps -aq)
+
+# -----------------------------------------------------
+# Dele all our images.
+#[user@desktop]
+
+    podman rmi -f $(podman images -q)
+
+    podman rmi -f $(podman images -q)
+

--- a/bin/push.sh
+++ b/bin/push.sh
@@ -19,11 +19,6 @@
 #   </meta:licence>
 # </meta:header>
 #
-#zrq-notes-time
-#zrq-notes-indent
-#zrq-notes-crypto
-#zrq-notes-ansible
-#zrq-notes-osformat
 #
 
 # -----------------------------------------------------

--- a/bin/push.sh
+++ b/bin/push.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#
+
+# -----------------------------------------------------
+# Set the build date.
+#[user@desktop]
+
+    buildtag=$(date '+%Y.%m.%d')
+
+# -----------------------------------------------------
+# Check our secret function works.
+#[user@desktop]
+
+    secret frog
+
+# -----------------------------------------------------
+# Login to the Docker registry.
+#[user@desktop]
+
+    podman login \
+        --username $(secret docker.io.user) \
+        --password $(secret docker.io.pass) \
+        registry-1.docker.io
+
+    #
+    # New behaviour - podman needs the registry name here.
+    #
+
+# -----------------------------------------------------
+# Push our images to Docker hub.
+#[user@desktop]
+
+    podman push "atolmis/fedora:${buildtag:?}"
+    podman push "atolmis/fedora:latest"
+
+    podman push "atolmis/openssh-client:${buildtag:?}"
+    podman push "atolmis/openssh-client:latest"
+
+    podman push "atolmis/kubernetes-client:${buildtag:?}"
+    podman push "atolmis/kubernetes-client:latest"
+
+    podman push "atolmis/openstack-client:${buildtag:?}"
+    podman push "atolmis/openstack-client:latest"
+
+    podman push "atolmis/ansible-client:${buildtag:?}"
+    podman push "atolmis/ansible-client:latest"
+
+    podman push "atolmis/terraform-client:${buildtag:?}"
+    podman push "atolmis/terraform-client:latest"
+
+

--- a/docker/digitalocean-client/Dockerfile
+++ b/docker/digitalocean-client/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+# Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
 # All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 
 ARG buildtag
 
-FROM atolmis/openssh-client:${buildtag}
+FROM atolmis/kubernetes-client:${buildtag}
 
 # https://docs.docker.com/v17.09/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG buildtag
@@ -29,22 +29,20 @@ LABEL buildtime="${buildtime}"
 LABEL gitrepo="https://github.com/wfau/atolmis"
 
 #
-# Install the Kubernetes client.
-RUN dnf install -y kubernetes-client
+# Install the DigitalOcean client.
+# https://github.com/digitalocean/doctl/releases
+ENV DOCTL_ARCH linux-amd64
+ENV DOCTL_VERSION 1.64.0
+ENV DOCTL_TARFILE doctl-${DOCTL_VERSION}-${DOCTL_ARCH}.tar.gz
+ENV DOCTL_DOWNLOAD https://github.com/digitalocean/doctl/releases/download
 
-#
-# Install Helm.
-# https://helm.sh/docs/intro/install/
-# https://github.com/helm/helm/releases
-ENV HELM_ARCH linux-amd64
-ENV HELM_VERSION 3.6.3
-ENV HELM_TARFILE helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz
+ADD ${DOCTL_DOWNLOAD}/v${DOCTL_VERSION}/${DOCTL_TARFILE} /tmp/${DOCTL_TARFILE}
+RUN tar --directory /tmp --gzip --extract --file /tmp/${DOCTL_TARFILE}
+RUN mv  /tmp/doctl /usr/local/bin/doctl
 
-ADD https://get.helm.sh/${HELM_TARFILE} /tmp/${HELM_TARFILE}
-RUN tar --directory /tmp --gzip --extract --file /tmp/${HELM_TARFILE}
-RUN mv  /tmp/${HELM_ARCH}/helm /usr/local/bin/helm
 
-#
-# Install the S3 client
-RUN dnf install -y s3cmd
+
+
+
+
 

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -61,6 +61,10 @@ RUN dnf install -y \
 RUN dnf install -y jq
 
 #
+# Install YAML lint.
+RUN dnf install -y yamllint
+
+#
 # Install the ipcalc tools.
 # http://jodies.de/ipcalc
 RUN dnf install -y ipcalc

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# FROM fedora:32
-# https://github.com/docker-library/repo-info/blob/master/repos/fedora/tag-details.md#fedora32
-FROM fedora@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
+# FROM fedora:33
+# https://github.com/docker-library/repo-info/blob/master/repos/fedora/tag-details.md#fedora33
+FROM fedora@sha256:aa889c59fc048b597dcfab40898ee3fcaad9ed61caf12bcfef44493ee670e9df
 
 # https://docs.docker.com/v17.09/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG buildtag
@@ -65,15 +65,14 @@ RUN dnf install -y jq
 RUN dnf install -y yamllint
 
 #
+# Install YAML parser.
+RUN wget -O   '/usr/bin/yq' 'https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64'
+RUN chmod a+x '/usr/bin/yq'
+
+#
 # Install the ipcalc tools.
 # http://jodies.de/ipcalc
 RUN dnf install -y ipcalc
-
-#
-# Set the terminal type for exec.
-# https://github.com/docker/docker/issues/9299
-# Looks like this is fixed in Fedora-30
-#ENV TERM xterm
 
 #
 # Add our install scripts.

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -15,9 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# FROM fedora:33
-# https://github.com/docker-library/repo-info/blob/master/repos/fedora/tag-details.md#fedora33
-FROM fedora@sha256:aa889c59fc048b597dcfab40898ee3fcaad9ed61caf12bcfef44493ee670e9df
+FROM fedora:34
 
 # https://docs.docker.com/v17.09/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG buildtag
@@ -36,6 +34,7 @@ VOLUME /var/cache/yum
 #
 # Install common admin tools.
 RUN dnf install -y \
+    dateutils \
     diffutils \
     findutils \
     gnupg \
@@ -65,8 +64,8 @@ RUN dnf install -y jq
 RUN dnf install -y yamllint
 
 #
-# Install YAML parser.
-RUN wget -O   '/usr/bin/yq' 'https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64'
+# Install yq YAML parser.
+RUN wget -O   '/usr/bin/yq' 'https://github.com/mikefarah/yq/releases/download/v4.12.0/yq_linux_amd64'
 RUN chmod a+x '/usr/bin/yq'
 
 #

--- a/docker/kubernetes-client/Dockerfile
+++ b/docker/kubernetes-client/Dockerfile
@@ -35,9 +35,9 @@ RUN dnf install -y kubernetes-client
 #
 # Install Helm.
 # https://helm.sh/docs/intro/install/
-# https://github.com/helm/helm/releases/tag/v3.2.4
+# https://github.com/helm/helm/releases/tag/v3.4.1
 ENV HELM_ARCH linux-amd64
-ENV HELM_VERSION 3.2.4
+ENV HELM_VERSION 3.4.1
 ENV HELM_TARFILE helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz
 
 # Download the tar file

--- a/docker/openstack-client/Dockerfile
+++ b/docker/openstack-client/Dockerfile
@@ -61,10 +61,6 @@ RUN pip3 install \
     python-openstackclient
 
 #
-# Install a S3 client
-RUN dnf install -y s3cmd
-
-#
 # Add our util scripts.
 COPY bin /usr/local/bin/
 RUN chmod a+x /usr/local/bin/*.sh

--- a/docker/terraform-client/Dockerfile
+++ b/docker/terraform-client/Dockerfile
@@ -34,7 +34,7 @@ LABEL gitrepo="https://github.com/wfau/atolmis"
 # https://github.com/RSE-Cambridge/iris-magnum/blob/master/magnum-tour/README.md
 # https://computingforgeeks.com/how-to-install-terraform-on-fedora/
 
-ENV TERRA_VERSION 0.12.28
+ENV TERRA_VERSION 0.13.5
 ENV TERRA_ZIPFILE terraform_${TERRA_VERSION}_linux_amd64.zip
 
 # Download the tar file

--- a/docker/terraform-client/Dockerfile
+++ b/docker/terraform-client/Dockerfile
@@ -34,7 +34,7 @@ LABEL gitrepo="https://github.com/wfau/atolmis"
 # https://github.com/RSE-Cambridge/iris-magnum/blob/master/magnum-tour/README.md
 # https://computingforgeeks.com/how-to-install-terraform-on-fedora/
 
-ENV TERRA_VERSION 0.13.5
+ENV TERRA_VERSION 1.0.5
 ENV TERRA_ZIPFILE terraform_${TERRA_VERSION}_linux_amd64.zip
 
 # Download the tar file

--- a/docker/terraform-client/Dockerfile
+++ b/docker/terraform-client/Dockerfile
@@ -34,7 +34,7 @@ LABEL gitrepo="https://github.com/wfau/atolmis"
 # https://github.com/RSE-Cambridge/iris-magnum/blob/master/magnum-tour/README.md
 # https://computingforgeeks.com/how-to-install-terraform-on-fedora/
 
-ENV TERRA_VERSION 0.12.26
+ENV TERRA_VERSION 0.12.28
 ENV TERRA_ZIPFILE terraform_${TERRA_VERSION}_linux_amd64.zip
 
 # Download the tar file

--- a/notes/zrq/20200617-01-updates.txt
+++ b/notes/zrq/20200617-01-updates.txt
@@ -18,11 +18,6 @@
 #   </meta:licence>
 # </meta:header>
 #
-#zrq-notes-time
-#zrq-notes-indent
-#zrq-notes-crypto
-#zrq-notes-ansible
-#zrq-notes-osformat
 #
 
 # -----------------------------------------------------

--- a/notes/zrq/20200629-01-updates.txt
+++ b/notes/zrq/20200629-01-updates.txt
@@ -1,0 +1,117 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#
+
+# -----------------------------------------------------
+# Build our containers.
+#[user@desktop]
+
+    buildtag=$(date '+%Y.%m.%d')
+    buildtime=$(date '+%Y-%m-%dT%H:%M:%S')
+
+    source "${HOME}/atolmis.env"
+    pushd "${ATOLMIS_CODE:?}"
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/fedora:latest \
+            --tag atolmis/fedora:${buildtag:?} \
+            docker/fedora
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openssh-client:latest \
+            --tag atolmis/openssh-client:${buildtag:?} \
+            docker/openssh-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/kubernetes-client:latest \
+            --tag atolmis/kubernetes-client:${buildtag:?} \
+            docker/kubernetes-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openstack-client:latest \
+            --tag atolmis/openstack-client:${buildtag:?} \
+            docker/openstack-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/ansible-client:latest \
+            --tag atolmis/ansible-client:${buildtag:?} \
+            docker/ansible-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/terraform-client:latest \
+            --tag atolmis/terraform-client:${buildtag:?} \
+            docker/terraform-client
+
+    popd
+
+# -----------------------------------------------------
+# Login to the Docker registry.
+#[user@desktop]
+
+    podman login \
+        --username $(secret docker.io.user) \
+        --password $(secret docker.io.pass) \
+        registry-1.docker.io
+
+    #
+    # New behaviour - podman needs the registry name here.
+    #
+
+# -----------------------------------------------------
+# Push our images to Docker hub.
+#[user@desktop]
+
+    podman push "atolmis/fedora:${buildtag:?}"
+    podman push "atolmis/fedora:latest"
+
+    podman push "atolmis/openssh-client:${buildtag:?}"
+    podman push "atolmis/openssh-client:latest"
+
+    podman push "atolmis/kubernetes-client:${buildtag:?}"
+    podman push "atolmis/kubernetes-client:latest"
+
+    podman push "atolmis/openstack-client:${buildtag:?}"
+    podman push "atolmis/openstack-client:latest"
+
+    podman push "atolmis/ansible-client:${buildtag:?}"
+    podman push "atolmis/ansible-client:latest"
+
+    podman push "atolmis/terraform-client:${buildtag:?}"
+    podman push "atolmis/terraform-client:latest"
+
+

--- a/notes/zrq/20200629-01-updates.txt
+++ b/notes/zrq/20200629-01-updates.txt
@@ -18,11 +18,6 @@
 #   </meta:licence>
 # </meta:header>
 #
-#zrq-notes-time
-#zrq-notes-indent
-#zrq-notes-crypto
-#zrq-notes-ansible
-#zrq-notes-osformat
 #
 
 # -----------------------------------------------------

--- a/notes/zrq/20201130-01-updates.txt
+++ b/notes/zrq/20201130-01-updates.txt
@@ -18,11 +18,6 @@
 #   </meta:licence>
 # </meta:header>
 #
-#zrq-notes-time
-#zrq-notes-indent
-#zrq-notes-crypto
-#zrq-notes-ansible
-#zrq-notes-osformat
 #
 
 

--- a/notes/zrq/20201130-01-updates.txt
+++ b/notes/zrq/20201130-01-updates.txt
@@ -1,0 +1,118 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#
+
+
+# -----------------------------------------------------
+# Build our containers.
+#[user@desktop]
+
+    buildtag=$(date '+%Y.%m.%d')
+    buildtime=$(date '+%Y-%m-%dT%H:%M:%S')
+
+    source "${HOME}/atolmis.env"
+    pushd "${ATOLMIS_CODE:?}"
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/fedora:latest \
+            --tag atolmis/fedora:${buildtag:?} \
+            docker/fedora
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openssh-client:latest \
+            --tag atolmis/openssh-client:${buildtag:?} \
+            docker/openssh-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/kubernetes-client:latest \
+            --tag atolmis/kubernetes-client:${buildtag:?} \
+            docker/kubernetes-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openstack-client:latest \
+            --tag atolmis/openstack-client:${buildtag:?} \
+            docker/openstack-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/ansible-client:latest \
+            --tag atolmis/ansible-client:${buildtag:?} \
+            docker/ansible-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/terraform-client:latest \
+            --tag atolmis/terraform-client:${buildtag:?} \
+            docker/terraform-client
+
+    popd
+
+# -----------------------------------------------------
+# Login to the Docker registry.
+#[user@desktop]
+
+    podman login \
+        --username $(secret docker.io.user) \
+        --password $(secret docker.io.pass) \
+        registry-1.docker.io
+
+    #
+    # New behaviour - podman needs the registry name here.
+    #
+
+# -----------------------------------------------------
+# Push our images to Docker hub.
+#[user@desktop]
+
+    podman push "atolmis/fedora:${buildtag:?}"
+    podman push "atolmis/fedora:latest"
+
+    podman push "atolmis/openssh-client:${buildtag:?}"
+    podman push "atolmis/openssh-client:latest"
+
+    podman push "atolmis/kubernetes-client:${buildtag:?}"
+    podman push "atolmis/kubernetes-client:latest"
+
+    podman push "atolmis/openstack-client:${buildtag:?}"
+    podman push "atolmis/openstack-client:latest"
+
+    podman push "atolmis/ansible-client:${buildtag:?}"
+    podman push "atolmis/ansible-client:latest"
+
+    podman push "atolmis/terraform-client:${buildtag:?}"
+    podman push "atolmis/terraform-client:latest"
+
+

--- a/notes/zrq/20210824-01-updates.txt
+++ b/notes/zrq/20210824-01-updates.txt
@@ -1,0 +1,169 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+
+
+# -----------------------------------------------------
+# -----------------------------------------------------
+
+    The new version of bash in Fedor-34 has bracketed-paste mode enabled.
+    This means when you paste text into the shell, it leaves it highlighted and does not execute it.
+    You need to explicitly add a <return> yourself.
+    This was changed because of security (websites injecting extra code into clipboard).
+
+    To set this back to the original behaviour:
+
+        set enable-bracketed-paste Off
+
+    Quote:
+
+        I've found it annoying, but without knowing what it was.
+        Now I'm not sure whether to keep or disable it.
+        -- seth
+
+    https://bugzilla.redhat.com/show_bug.cgi?id=1954366
+    https://utcc.utoronto.ca/~cks/space/blog/unix/BashBracketedPasteChange?showcomments#comments
+    https://askubuntu.com/questions/662222/why-bracketed-paste-mode-is-enabled-sporadically-in-my-terminal-screen
+
+    Looks like this will be the new normal from now on.
+    Get used to it, or forever be editing .bashrc to switch it off.
+
+# -----------------------------------------------------
+# -----------------------------------------------------
+
+
+# -----------------------------------------------------
+# Create a new branch to work on.
+#[user@desktop]
+
+    source "${HOME}/atolmis.env"
+    pushd "${ATOLMIS_CODE:?}"
+
+        newbranch=$(date '+%Y%m%d')-zrq-updates
+
+        git checkout master
+        git checkout -b "${newbranch:?}"
+
+        git push --set-upstream 'origin' "$(git branch --show-current)"
+
+    popd
+
+
+# -----------------------------------------------------
+# Build our containers.
+#[user@desktop]
+
+    buildtag=$(date '+%Y.%m.%d')
+    buildtime=$(date '+%Y-%m-%dT%H:%M:%S')
+
+    source "${HOME}/atolmis.env"
+    pushd "${ATOLMIS_CODE:?}"
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/fedora:latest \
+            --tag atolmis/fedora:${buildtag:?} \
+            docker/fedora
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openssh-client:latest \
+            --tag atolmis/openssh-client:${buildtag:?} \
+            docker/openssh-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/kubernetes-client:latest \
+            --tag atolmis/kubernetes-client:${buildtag:?} \
+            docker/kubernetes-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/openstack-client:latest \
+            --tag atolmis/openstack-client:${buildtag:?} \
+            docker/openstack-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/ansible-client:latest \
+            --tag atolmis/ansible-client:${buildtag:?} \
+            docker/ansible-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/digitalocean-client:latest \
+            --tag atolmis/digitalocean-client:${buildtag:?} \
+            docker/digitalocean-client
+
+        podman build \
+            --build-arg "buildtag=${buildtag:?}" \
+            --build-arg "buildtime=${buildtime:?}" \
+            --tag atolmis/terraform-client:latest \
+            --tag atolmis/terraform-client:${buildtag:?} \
+            docker/terraform-client
+
+    popd
+
+# -----------------------------------------------------
+# Login to the Docker registry.
+#[user@desktop]
+
+    podman login \
+        --username $(secret docker.io.user) \
+        --password $(secret docker.io.pass) \
+        registry-1.docker.io
+
+    #
+    # New behaviour - podman needs the registry name here.
+    #
+
+# -----------------------------------------------------
+# Push our images to Docker hub.
+#[user@desktop]
+
+    podman push "atolmis/fedora:${buildtag:?}"
+    podman push "atolmis/fedora:latest"
+
+    podman push "atolmis/openssh-client:${buildtag:?}"
+    podman push "atolmis/openssh-client:latest"
+
+    podman push "atolmis/kubernetes-client:${buildtag:?}"
+    podman push "atolmis/kubernetes-client:latest"
+
+    podman push "atolmis/openstack-client:${buildtag:?}"
+    podman push "atolmis/openstack-client:latest"
+
+    podman push "atolmis/ansible-client:${buildtag:?}"
+    podman push "atolmis/ansible-client:latest"
+
+    podman push "atolmis/terraform-client:${buildtag:?}"
+    podman push "atolmis/terraform-client:latest"
+
+    podman push "atolmis/digitalocean-client:${buildtag:?}"
+    podman push "atolmis/digitalocean-client:latest"
+


### PR DESCRIPTION
This PR updates versions of the tools in our containers. Including updating the base OS from Fedora-33 to Fedora-34.

The new version of bash in Fedor-34 has `bracketed-paste` mode enabled. This means when you paste text into the command 
line, it leaves it highlighted and does not execute it. You need to explicitly press [return] yourself.

To set this back to the original behaviour:

    set enable-bracketed-paste Off

* https://bugzilla.redhat.com/show_bug.cgi?id=1954366
* https://utcc.utoronto.ca/~cks/space/blog/unix/BashBracketedPasteChange?showcomments#comments
* https://askubuntu.com/questions/662222/why-bracketed-paste-mode-is-enabled-sporadically-in-my-terminal-screen

To quote one commenter on a forum:

> I've found it annoying, but without knowing what it was.
> Now I'm not sure whether to keep or disable it.
> -- seth

----

This PR also updates `yq` from version 3 to version 4, which will break almost all of the calls embedded in our notes and scripts.
To quote the `yq` developer :

> _"Version 4 of yq is quite different from previous versions (and I apologise for that) - however it will be very familiar if you have used jq before as it now uses a similar syntax. Most commands that you could do in v3 are longer in v4 as a result of having a more expressive syntax language."_
>  -- Mike Farah 
> https://mikefarah.gitbook.io/yq/upgrading-from-v3
